### PR TITLE
Allow optional phoenix socket configuration

### DIFF
--- a/src/LiveState.ts
+++ b/src/LiveState.ts
@@ -11,6 +11,9 @@ export type LiveStateConfig = {
 
   /** will be sent as params on channel join */
   params?: object
+
+  /** the options passed to the phoenix socket */
+  socketOptions?: object
 }
 
 export type LiveStateError = {
@@ -83,7 +86,10 @@ export class LiveState implements EventTarget {
 
   constructor(config: LiveStateConfig) {
     this.config = config;
-    this.socket = new Socket(this.config.url, { logger: ((kind, msg, data) => { console.log(`${kind}: ${msg}`, data) }) });
+    this.socket = new Socket(
+      this.config.url,
+      this.config.socketOptions || { logger: ((kind, msg, data) => { console.log(`${kind}: ${msg}`, data) }) }
+    );
     this.channel = this.socket.channel(this.config.topic, this.config.params);
     this.eventTarget = new EventTarget();
   }

--- a/test/decorator-test.ts
+++ b/test/decorator-test.ts
@@ -13,6 +13,9 @@ class InstanceDecorated {
 
   @liveStateConfig('url')
   get theUrl() { return 'bobbida'; }
+
+  @liveStateConfig('socketOptions')
+  socketOptions: object = { logger: null };
 }
 
 describe('liveStateConfig', () => {
@@ -22,5 +25,6 @@ describe('liveStateConfig', () => {
     expect(config.topic).to.eql('stuff');
     expect(config.url).to.eql('bobbida');
     expect(config.params['foo']).to.eql('other stuff'); 
+    expect(config.socketOptions['logger']).to.eql(null);
   });
 });


### PR DESCRIPTION
First of all, thank you for this great library!

### Actual behaviour

The options passed to the phoenix socket are hard-coded in the library.
In particular, the `logger` socket option is set to log to the browser console.

### Problem

I needed to disable the logging in production (`NODE_ENV === 'production'`).

### New behaviour

The phoenix socket options can be given through the `LiveState` config:

```js
const liveState = new LiveState({
  url: 'http://localhost:4000/live_state_socket',
  topic: 'some_topic',
  params: {
    // some params
  },
  socketOptions: {
    logger: null
  },
});
```

This new `socketOptions` key is optional in the configuration.
If undefined, it falls back to the original behaviour (logs to the console).